### PR TITLE
Allow for a sort indicator component

### DIFF
--- a/addon/components/yeti-table/head/component.js
+++ b/addon/components/yeti-table/head/component.js
@@ -2,7 +2,7 @@ import Component from '@ember/component';
 
 import { tagName, className } from '@ember-decorators/component';
 import { argument } from '@ember-decorators/argument';
-import { arrayOf, unionOf } from '@ember-decorators/argument/types';
+import { arrayOf, unionOf, optional } from '@ember-decorators/argument/types';
 import { Action } from '@ember-decorators/argument/types';
 import { reads } from '@ember-decorators/object/computed';
 
@@ -47,6 +47,13 @@ class Head extends Component {
 
   @argument(Action)
   onColumnClick;
+
+  /**
+   * Should the sort classes be applied to the sortIndicator component or the column `td`.
+   * By default the sort classes are applied to the columnd `td`
+   */
+  @argument(optional('boolean'))
+  useSortIndicator = false;
 
   @className
   @reads('theme.thead')

--- a/addon/components/yeti-table/head/row/column/component.js
+++ b/addon/components/yeti-table/head/row/column/component.js
@@ -1,4 +1,5 @@
 import Component from '@ember/component';
+import { get } from '@ember/object';
 import { assert } from '@ember/debug';
 import { isArray } from '@ember/array';
 import DidChangeAttrsComponent from 'ember-yeti-table/-private/utils/did-change-attrs-component';
@@ -97,6 +98,9 @@ class Column extends DidChangeAttrsComponent {
   @argument(unionOf('string', arrayOf('string')))
   sortSequence;
 
+  @argument('boolean')
+  useSortIndicator;
+
   /**
    * Used to turn off filtering for this column. When `false`, Yeti Table won't look for
    * values on this column. Defaults to `true`.
@@ -160,6 +164,20 @@ class Column extends DidChangeAttrsComponent {
       return sortSequence.split(',').map((s) => s.trim());
     } else {
       return [];
+    }
+  }
+
+  @computed('useSortIndicator', 'isAscSorted', 'isDescSorted', 'theme.sorting.{columnSortedAsc,columnSortedDesc}')
+  get sortDirectionClass() {
+    if (this.useSortIndicator == false) {
+      if (this.isAscSorted) {
+        return get(this, 'theme.sorting.columnSortedAsc');
+      }
+      if (this.isDescSorted) {
+        return get(this, 'theme.sorting.columnSortedDesc');
+      }
+    } else {
+      return '';
     }
   }
 

--- a/addon/components/yeti-table/head/row/column/component.js
+++ b/addon/components/yeti-table/head/row/column/component.js
@@ -176,9 +176,9 @@ class Column extends DidChangeAttrsComponent {
       if (this.isDescSorted) {
         return get(this, 'theme.sorting.columnSortedDesc');
       }
-    } else {
-      return '';
     }
+
+    return '';
   }
 
   init() {

--- a/addon/components/yeti-table/head/row/column/component.js
+++ b/addon/components/yeti-table/head/row/column/component.js
@@ -169,7 +169,7 @@ class Column extends DidChangeAttrsComponent {
 
   @computed('useSortIndicator', 'isAscSorted', 'isDescSorted', 'theme.sorting.{columnSortedAsc,columnSortedDesc}')
   get sortDirectionClass() {
-    if (this.useSortIndicator == false) {
+    if (this.useSortIndicator === false) {
       if (this.isAscSorted) {
         return get(this, 'theme.sorting.columnSortedAsc');
       }

--- a/addon/components/yeti-table/head/row/column/template.hbs
+++ b/addon/components/yeti-table/head/row/column/template.hbs
@@ -1,13 +1,21 @@
 {{#if visible}}
   <th
     role={{if sortable "button"}}
-    class="{{class}} {{theme.theadCell}} {{if sortable theme.sorting.columnSortable}} {{if isSorted theme.sorting.columnSorted}} {{if isAscSorted theme.sorting.columnSortedAsc}} {{if isDescSorted theme.sorting.columnSortedDesc}}"
+    class="{{class}} {{theme.theadCell}} {{if sortable theme.sorting.columnSortable}}
+      {{if isSorted theme.sorting.columnSorted}}
+      {{sortDirectionClass}}
+      "
     onclick={{if sortable (action onClick this)}}
     ...attributes>
     {{yield (hash
       isSorted=isSorted
       isAscSorted=isAscSorted
       isDescSorted=isDescSorted
+      sortIndicator=(component "yeti-table/sort-indicator"
+        isSorted=isSorted
+        isAscSorted=isAscSorted
+        isDescSorted=isDescSorted
+        theme=theme)
     )}}
   </th>
 {{/if}}

--- a/addon/components/yeti-table/head/row/component.js
+++ b/addon/components/yeti-table/head/row/component.js
@@ -50,6 +50,9 @@ class Row extends Component {
   @argument(Action)
   onColumnClick;
 
+  @argument(optional('boolean'))
+  useSortIndicator = false;
+
   cells = A();
 
   registerCell(cell) {

--- a/addon/components/yeti-table/head/row/template.hbs
+++ b/addon/components/yeti-table/head/row/template.hbs
@@ -1,6 +1,7 @@
 <tr class="{{trClass}} {{theme.theadRow}} {{theme.row}}" ...attributes>
   {{yield (hash
-    column=(component "yeti-table/head/row/column" sortable=sortable sortSequence=sortSequence onClick=onColumnClick theme=theme parent=parent)
+    column=(component "yeti-table/head/row/column" sortable=sortable sortSequence=sortSequence
+      onClick=onColumnClick theme=theme parent=parent useSortIndicator=useSortIndicator)
     cell=(component "yeti-table/head/row/cell" theme=theme parent=this)
   )}}
 </tr>

--- a/addon/components/yeti-table/head/template.hbs
+++ b/addon/components/yeti-table/head/template.hbs
@@ -1,3 +1,4 @@
 {{yield (hash
-  row=(component "yeti-table/head/row" sortable=sortable sortSequence=sortSequence onColumnClick=onColumnClick columns=columns theme=theme parent=parent)
+  row=(component "yeti-table/head/row" sortable=sortable sortSequence=sortSequence
+    onColumnClick=onColumnClick columns=columns theme=theme parent=parent useSortIndicator=useSortIndicator)
 )}}

--- a/addon/components/yeti-table/header/component.js
+++ b/addon/components/yeti-table/header/component.js
@@ -56,6 +56,13 @@ class Header extends Component {
   @reads('theme.thead')
   themeClass;
 
+  /**
+   * Should the sort classes be applied to the sortIndicator component or the column `td`.
+   * By default the sort classes are applied to the columnd `td`
+   */
+  @argument(optional('boolean'))
+  useSortIndicator = false;
+
   @action
   onColumnClick(column, e) {
     if (this.get('onColumnClick') && column.get('sortable')) {

--- a/addon/components/yeti-table/header/template.hbs
+++ b/addon/components/yeti-table/header/template.hbs
@@ -1,5 +1,6 @@
 <tr class="{{trClass}} {{theme.theadRow}} {{theme.row}}">
   {{yield (hash
-    column=(component "yeti-table/head/row/column" sortable=sortable sortSequence=sortSequence onClick=(action "onColumnClick") parent=parent theme=theme)
+    column=(component "yeti-table/head/row/column" sortable=sortable sortSequence=sortSequence
+      onClick=(action "onColumnClick") parent=parent theme=theme useSortIndicator=useSortIndicator)
   )}}
 </tr>

--- a/addon/components/yeti-table/sort-indicator/component.js
+++ b/addon/components/yeti-table/sort-indicator/component.js
@@ -1,0 +1,52 @@
+import Component from '@ember/component';
+
+import { tagName } from '@ember-decorators/component';
+import { argument } from '@ember-decorators/argument';
+
+import layout from './template';
+
+/**
+  Simple pagination controls component that is included to help you get started quickly.
+  Yeti Table yields a lot of pagination data, so you shouldn't have a problem
+  creating your own pagination controls.
+
+  At any rate, this component tries to be as flexible as possible. Some arguments
+  are provided to customize how this component behaves.
+
+  If you want to render these controls on the table footer, you probably want
+  a footer row that always spans all rows. To do that you can use a `colspan` equal
+  to the yielded `visibleColumns` number. Example:
+
+  ```hbs
+  <YetiTable @data={{data}} @pagination={{true}} as |table|>
+    ...
+    <table.foot as |foot|>
+      <foot.row as |row|>
+        <row.cell colspan={{table.visibleColumns}}>
+          <table.pagination/>
+        </row.cell>
+      </foot.row>
+    </table.foot>
+  </YetiTable>
+  ```
+*/
+
+@tagName('')
+class SortIndicator extends Component {
+  layout = layout;
+
+  @argument('boolean')
+  isSorted;
+
+  @argument('boolean')
+  isAscSorted;
+
+  @argument('boolean')
+  isDescSorted;
+
+  @argument('object')
+  theme;
+
+}
+
+export default SortIndicator;

--- a/addon/components/yeti-table/sort-indicator/template.hbs
+++ b/addon/components/yeti-table/sort-indicator/template.hbs
@@ -1,0 +1,7 @@
+{{#if hasBlock}}
+  {{yield (hash isSorted=@isSorted isAscSorted=@isAscSorted isDescSorted=@isDescSorted theme=@theme)}}
+{{else}}
+  {{#if @isSorted}}
+    <i class="{{if @isAscSorted @theme.sorting.columnSortedAsc}} {{if @isDescSorted @theme.sorting.columnSortedDesc}}" />
+  {{/if}}
+{{/if}}

--- a/app/components/yeti-table/sort-indicator.js
+++ b/app/components/yeti-table/sort-indicator.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-yeti-table/components/yeti-table/sort-indicator/component';

--- a/tests/integration/components/yeti-table/sorting-test.js
+++ b/tests/integration/components/yeti-table/sorting-test.js
@@ -750,6 +750,66 @@ module('Integration | Component | yeti-table (sorting)', function(hooks) {
     assert.dom('thead tr:nth-child(1) th:nth-child(1)').hasClass(DEFAULT_THEME.sorting.columnSortedDesc);
   });
 
+  test('sort does not apply sort direction class to header column when @useSortIndicator={{true}}', async function(assert) {
+    await render(hbs`
+      <YetiTable @data={{data}} as |table|>
+
+        <table.header @useSortIndicator={{true}} as |header|>
+          <header.column @prop="firstName" @sort="asc" as |column|>
+            First name
+            <column.sortIndicator/>
+          </header.column>
+          <header.column @prop="lastName" @sort="desc" as |column|>
+            Last name
+            <column.sortIndicator/>
+          </header.column>
+          <header.column @prop="points">
+            Points
+          </header.column>
+        </table.header>
+
+        <table.body/>
+
+      </YetiTable>
+    `);
+
+    assert.dom('thead tr:nth-child(1) th:nth-child(1)').doesNotHaveClass(DEFAULT_THEME.sorting.columnSortedAsc);
+    assert.dom('thead tr:nth-child(1) th:nth-child(1) i').hasClass(DEFAULT_THEME.sorting.columnSortedAsc);
+
+    assert.dom('thead tr:nth-child(1) th:nth-child(2)').doesNotHaveClass(DEFAULT_THEME.sorting.columnSortedDesc);
+    assert.dom('thead tr:nth-child(1) th:nth-child(2) i').hasClass(DEFAULT_THEME.sorting.columnSortedDesc);
+
+    await render(hbs`
+      <YetiTable @data={{data}} as |table|>
+
+        <table.head @useSortIndicator={{true}} as |head|>
+          <head.row as |row|>
+            <row.column @prop="firstName" @sort="asc" as |column|>
+              First name
+              <column.sortIndicator/>
+            </row.column>
+            <row.column @prop="lastName" @sort="desc" as |column|>
+              Last name
+              <column.sortIndicator/>
+            </row.column>
+            <row.column @prop="points">
+              Points
+            </row.column>
+          </head.row>        
+        </table.head>
+
+        <table.body/>
+
+      </YetiTable>
+    `);
+
+    assert.dom('thead tr:nth-child(1) th:nth-child(1)').doesNotHaveClass(DEFAULT_THEME.sorting.columnSortedAsc);
+    assert.dom('thead tr:nth-child(1) th:nth-child(1) i').hasClass(DEFAULT_THEME.sorting.columnSortedAsc);
+
+    assert.dom('thead tr:nth-child(1) th:nth-child(2)').doesNotHaveClass(DEFAULT_THEME.sorting.columnSortedDesc);
+    assert.dom('thead tr:nth-child(1) th:nth-child(2) i').hasClass(DEFAULT_THEME.sorting.columnSortedDesc);
+  });
+
   test('clicking on column header applies correct class', async function(assert) {
     await render(hbs`
       <YetiTable @data={{data}} as |table|>
@@ -828,4 +888,41 @@ module('Integration | Component | yeti-table (sorting)', function(hooks) {
     assert.dom('thead tr:nth-child(1) th:nth-child(1) .down-arrow').exists();
     assert.dom('thead tr:nth-child(1) th:nth-child(1) .up-arrow').doesNotExist();
   });
+
+  test('clicking on column header applies correct class', async function(assert) {
+    await render(hbs`
+      <YetiTable @data={{data}} as |table|>
+
+        <table.header as |header|>
+          <header.column @prop="firstName">
+            First name
+          </header.column>
+          <header.column @prop="lastName">
+            Last name
+          </header.column>
+          <header.column @prop="points">
+            Points
+          </header.column>
+        </table.header>
+
+        <table.body/>
+
+      </YetiTable>
+    `);
+
+    // not sorted
+    assert.dom('thead tr:nth-child(1) th:nth-child(1)').doesNotHaveClass(DEFAULT_THEME.sorting.columnSortedAsc);
+    assert.dom('thead tr:nth-child(1) th:nth-child(1)').doesNotHaveClass(DEFAULT_THEME.sorting.columnSortedDesc);
+
+    await click('thead th:nth-child(1)');
+
+    // it is sorted ascending
+    assert.dom('thead tr:nth-child(1) th:nth-child(1)').hasClass(DEFAULT_THEME.sorting.columnSortedAsc);
+
+    await click('thead th:nth-child(1)');
+
+    // it is sorted descending
+    assert.dom('thead tr:nth-child(1) th:nth-child(1)').hasClass(DEFAULT_THEME.sorting.columnSortedDesc);
+  });
+
 });


### PR DESCRIPTION
Documentation not complete, wanted to finalize request before updating.

Currently the sort classes are applied to the `td` of the column. When I apply the bootstrap class I am currently using, the class is applying to the text contained within the `td` and doing strand things. Additionally I would like the indicator on the end of the text instead of before.

This provides the following
```
      <YetiTable @data={{data}} as |table|>

        <table.header @useSortIndicator={{true}} as |header|>
          <header.column @prop="firstName" @sort="asc" as |column|>
            First name
            <column.sortIndicator/>
          </header.column>
          <header.column @prop="lastName" @sort="desc" as |column|>
            <column.sortIndicator/>
            Last name
          </header.column>
          <header.column @prop="points">
            Points
          </header.column>
        </table.header>

        <table.body/>

      </YetiTable>

```
Allows the sort classes to be applied to not the column `td` but to a component within the `td`. Also allows the sort indicator to be placed before or after the text. Generally gives more control to the look and placement of the indicator.
