### PR TITLE
Enable some properties to be defaulted in the config

### DIFF
--- a/addon/components/yeti-table/component.js
+++ b/addon/components/yeti-table/component.js
@@ -118,8 +118,8 @@ class YetiTable extends DidChangeAttrsComponent {
    * html elements. The theme object your pass in will be deeply merged with yeti-table's default theme
    * and with a theme defined in your environment.js at `ENV['ember-yeti-table'].theme`.
    */
-  @argument(optional('object'))
-  theme;
+  @argument('object')
+  theme = {};
 
   /**
    * The data for Yeti Table to render. It can be an array or a promise that resolves with an array.
@@ -150,13 +150,13 @@ class YetiTable extends DidChangeAttrsComponent {
    * Use this argument to enable the pagination feature. Default is `false`.
    */
   @argument('boolean')
-  pagination = false;
+  pagination = this.get('config').pagination === undefined ? false : this.get('config').pagination;
 
   /**
    * Controls the size of each page. Default is `15`.
    */
   @argument('number')
-  pageSize = 15;
+  pageSize = this.get('config').pageSize || 15;
 
   /**
    * Controls the current page to show. Default is `1`.
@@ -207,7 +207,7 @@ class YetiTable extends DidChangeAttrsComponent {
    * the @sortable argument to all columns.
    */
   @argument('boolean')
-  sortable = true;
+  sortable = this.get('config').sortable === undefined ? true : this.get('config').sortable;
 
   /**
    * Use the `@sortFunction` if you want to completely customize how the row sorting is done.
@@ -230,15 +230,28 @@ class YetiTable extends DidChangeAttrsComponent {
    * of strings. Accepted values are `'asc'`, `'desc'` and `'unsorted'`. The default value is `['asc', 'desc']`.
    */
   @argument(unionOf('string', arrayOf('string')))
-  sortSequence = ['asc', 'desc'];
+  sortSequence = this.get('config').sortSequence || ['asc', 'desc'];
 
   @className
   @reads('mergedTheme.table')
   themeClass;
 
+  // If the theme is replaced, this will invalidate, but not if any prop under theme is changed
+  @computed('theme', 'config.theme')
+  get mergedTheme() {
+    let configTheme = this.get('config').theme ||  {};
+    let localTheme = this.get('theme');
+    return merge.all([DEFAULT_THEME, configTheme, localTheme]);
+  }
+
   isLoading = false;
 
   @filterBy('columns', 'visible', true) visibleColumns;
+
+  @computed
+  get config() {
+    return getOwner(this).resolveRegistration('config:environment')['ember-yeti-table'] || {};
+  }
 
   @computed('loadData', 'sortedData.[]', 'resolvedData.[]')
   get normalizedTotalRows() {
@@ -311,11 +324,6 @@ class YetiTable extends DidChangeAttrsComponent {
 
   init() {
     super.init(...arguments);
-
-    let config = getOwner(this).resolveRegistration('config:environment')['ember-yeti-table'];
-    let configTheme = config && config.theme ? config.theme : {};
-    let localTheme = this.get('theme') || {};
-    this.mergedTheme = merge.all([{}, DEFAULT_THEME, configTheme, localTheme]);
 
     this.columns = A();
     this.filteredData = [];

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -19,6 +19,10 @@ module.exports = function(environment) {
       }
     },
 
+    // 'ember-yeti-table': {
+    //   pagination: true
+    // },
+
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created


### PR DESCRIPTION
Should solve issue https://github.com/miguelcobain/ember-yeti-table/issues/22.

Allow for the following properties to have default values from the config.
pageSize
pagination
sortSequence
sortable