### PR TITLE
Fix filtering throwing an error when a column header does not have prop defined

### DIFF
--- a/addon/components/yeti-table/component.js
+++ b/addon/components/yeti-table/component.js
@@ -1,6 +1,6 @@
 import DidChangeAttrsComponent from 'ember-yeti-table/-private/utils/did-change-attrs-component';
 import { A } from '@ember/array';
-import { isEmpty } from '@ember/utils';
+import { isEmpty, isPresent } from '@ember/utils';
 import {
   computed as emberComputed,
   defineProperty
@@ -377,8 +377,8 @@ class YetiTable extends DidChangeAttrsComponent {
 
     defineProperty(this, 'filteredData', emberComputed(...filteredDataDeps, function() {
       let data = this.get('resolvedData');
-      // only columns that have filterable = true will be considered
-      let columns = this.get('columns').filter((c) => c.get('filterable'));
+      // only columns that have filterable = true and a prop defined will be considered
+      let columns = this.get('columns').filter((c) => c.get('filterable') && isPresent(c.get('prop')));
       let filter = this.get('filter');
       let filterFunction = this.get('filterFunction');
       let filterUsing = this.get('filterUsing');

--- a/tests/integration/components/yeti-table/filtering-test.js
+++ b/tests/integration/components/yeti-table/filtering-test.js
@@ -349,4 +349,32 @@ module('Integration | Component | yeti-table (filtering)', function(hooks) {
     assert.dom('tbody tr').exists({ count: 3 });
   });
 
+  test('Filtering works when a column header does not have a property', async function(assert) {
+    await render(hbs`
+      <YetiTable @data={{data}} @filter="Baderous" as |table|>
+
+        <table.header as |header|>
+          <header.column @prop="firstName">
+            First name
+          </header.column>
+          <header.column @prop="lastName">
+            Last name
+          </header.column>
+          <header.column @prop="points">
+            Points
+          </header.column>
+          <header.column>
+            Test blank column
+          </header.column>
+        </table.header>
+
+        <table.body/>
+
+      </YetiTable>
+    `);
+
+    assert.dom('tbody tr').exists({ count: 1 });
+
+    assert.dom('tbody tr:nth-child(1) td:nth-child(1)').hasText('José');
+  });
 });


### PR DESCRIPTION
Fixes issue https://github.com/miguelcobain/ember-yeti-table/issues/25

When a column does not have a prop defined, filtering will skip this column instead of throwing an error