### PR TITLE
Added events for capturing visible and filtered rows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@
 
 /.idea/
 /.gradle/
+*.iml

--- a/addon/components/yeti-table/component.js
+++ b/addon/components/yeti-table/component.js
@@ -120,6 +120,26 @@ class YetiTable extends DidChangeAttrsComponent {
    */
   loadData;
 
+  /**
+   * An optional function to access the filtered rows on the table outside of the Yeti Table component.
+   * By passing in a function to `@onFilteredRowsChanged` you can have access to the filtered
+   * rows when filtering is changed.
+   *
+   * This function will be called with one argument:
+   * - `rows` - the filtered rows
+   */
+  onFilteredRowsChanged;
+
+  /**
+   * An optional function to access the visible rows on the table outside of the Yeti Table component.
+   * By passing in a function to `@onVisibleRowsChanged` you can have access to the current visible
+   * rows.
+   *
+   * This function will be called with one argument:
+   * - `rows` - the current visible rows
+   */
+  onVisibleRowsChanged;
+
   publicApi = {
     previousPage: this.previousPage,
     nextPage: this.nextPage,
@@ -273,15 +293,20 @@ class YetiTable extends DidChangeAttrsComponent {
     }
   }
 
-  @computed('loadData', 'sortedData.[]', 'resolvedData.[]')
+  @computed('loadData', 'onFilteredRowsChanged', 'resolvedData.[]', 'sortedData.[]')
   get normalizedRows() {
+    let rows;
     if (!this.get('loadData')) {
       // sync scenario using @data
-      return this.get('sortedData');
+      rows = this.get('sortedData');
     } else {
       // async scenario. @loadData is present.
-      return this.get('resolvedData');
+      rows = this.get('resolvedData');
     }
+    if (this.onFilteredRowsChanged) {
+      this.onFilteredRowsChanged(rows);
+    }
+    return rows;
   }
 
   @computed('pageSize', 'pageNumber', 'normalizedTotalRows')
@@ -326,14 +351,19 @@ class YetiTable extends DidChangeAttrsComponent {
     return data;
   }
 
-  @computed('pagedData', 'resolvedData', 'loadData')
+  @computed('loadData', 'onVisibleRowsChanged', 'pagedData', 'resolvedData')
   get processedData() {
+    let rows;
     if (this.get('loadData')) {
       // skip processing and return raw data if remote data is enabled via `loadData`
-      return this.get('resolvedData');
+      rows = this.get('resolvedData');
     } else {
-      return this.get('pagedData');
+      rows = this.get('pagedData');
     }
+    if (this.onVisibleRowsChanged) {
+      this.onVisibleRowsChanged(rows);
+    }
+    return rows;
   }
 
   init() {

--- a/tests/integration/components/yeti-table/general-test.js
+++ b/tests/integration/components/yeti-table/general-test.js
@@ -4,6 +4,7 @@ import { setupRenderingTest } from 'ember-qunit';
 import { module, test } from 'qunit';
 
 import { A } from '@ember/array';
+import { set } from '@ember/object';
 
 import { hbs } from 'ember-cli-htmlbars';
 import sinon from 'sinon';
@@ -643,8 +644,15 @@ module('Integration | Component | yeti-table (general)', function (hooks) {
   });
 
   test('yielded columns, visibleColumns, totalRows and visibleRows are correct', async function (assert) {
+    this.onVisibleRowsChanged = rows => {
+      set(this, 'savedVisibleRows', rows);
+    };
+    this.onFilteredRowsChanged = rows => {
+      set(this, 'savedRows', rows);
+    };
+
     await render(hbs`
-      <YetiTable @data={{this.data}} as |table|>
+      <YetiTable @data={{this.data}} @onVisibleRowsChanged={{this.onVisibleRowsChanged}} @onFilteredRowsChanged={{this.onFilteredRowsChanged}} as |table|>
 
         <table.header as |header|>
           <header.column @prop="firstName">
@@ -670,6 +678,9 @@ module('Integration | Component | yeti-table (general)', function (hooks) {
         <div id="visibleRows">{{table.visibleRows.length}}</div>
 
       </YetiTable>
+      
+        <div id="savedRows">{{this.savedRows.length}}</div>
+        <div id="savedVisibleRows">{{this.savedVisibleRows.length}}</div>
     `);
 
     assert.dom('#totalColumns').hasText('4');
@@ -677,6 +688,8 @@ module('Integration | Component | yeti-table (general)', function (hooks) {
     assert.dom('#rows').hasText('5');
     assert.dom('#totalRows').hasText('5');
     assert.dom('#visibleRows').hasText('5');
+    assert.dom('#savedRows').hasText('5');
+    assert.dom('#savedVisibleRows').hasText('5');
   });
 
   test('can add arbitrary attributes to columns and cells', async function (assert) {


### PR DESCRIPTION
Both visible rows and rows were accessible only inside the YetiTable component. These additional events will be used to access these properties outside of the YetiTable component and within Javascript.  