### PR TITLE
fix typo in documentation

### DIFF
--- a/addon/components/yeti-table/thead/component.js
+++ b/addon/components/yeti-table/thead/component.js
@@ -14,7 +14,7 @@ import template from './template';
         First name
         {{if column.isAscSorted "(sorted asc)"}}
         {{if column.isDescSorted "(sorted desc)"}}
-      </head.column>
+      </row.column>
     </head.row>
   </table.thead>
   ```


### PR DESCRIPTION
`<row.column>` is opened but `<head.column>` was closed. This PR fixes that typo.