### PR TITLE
Fix double loadData on page turns

### DIFF
--- a/addon/components/yeti-table/component.js
+++ b/addon/components/yeti-table/component.js
@@ -572,7 +572,6 @@ class YetiTable extends DidChangeAttrsComponent {
     if (this.get('pagination')) {
       let { pageNumber } = this.get('paginationData');
       this.set('pageNumber', Math.max(pageNumber - 1, 1));
-      this.runLoadData();
     }
   }
 
@@ -583,7 +582,6 @@ class YetiTable extends DidChangeAttrsComponent {
 
       if (!isLastPage) {
         this.set('pageNumber', pageNumber + 1);
-        this.runLoadData();
       }
     }
   }
@@ -599,7 +597,6 @@ class YetiTable extends DidChangeAttrsComponent {
       }
 
       this.set('pageNumber', pageNumber);
-      this.runLoadData();
     }
   }
 

--- a/tests/integration/components/yeti-table/async-data-test.js
+++ b/tests/integration/components/yeti-table/async-data-test.js
@@ -495,8 +495,10 @@ module('Integration | Component | yeti-table (async)', function (hooks) {
       });
     });
 
+    this.set('pageNumber', 1);
+
     await render(hbs`
-      <YetiTable @loadData={{this.loadData}} @pagination={{true}} @totalRows={{10}} @pageSize={{5}} as |table|>
+      <YetiTable @loadData={{this.loadData}} @pagination={{true}} @totalRows={{10}} @pageSize={{5}} @pageNumber={{pageNumber}} as |table|>
 
         <table.header as |header|>
           <header.column @prop="firstName">


### PR DESCRIPTION
I found a bug with pagination where the `loadData` task was getting called twice. It looks like it is still happening even in later versions, even though we are still on `v0.1.1`.

Since `didChangeAttrs` is called when any of `YetiTable`s attributes change, and `didChangeAttrs` triggers a `loadData` task refire, it is not necessary to manually call `this.loadData()` from the `prevPage`, `nextPage`, or `goToPage` methods on the `YetiTable` component. 

In examples in documentation, `yield timeout(250)` is used on a `restartable()` task, so this behavior is hidden. Ideally, a page turn would be immediate and you should not need a `yield timeout(250)`. This timeout was a bandaid over this issue.