### PR TITLE
Converted table, thead/row/cell set, header to glimmer components

### DIFF
--- a/addon/components/yeti-table/body.js
+++ b/addon/components/yeti-table/body.js
@@ -36,7 +36,8 @@ class Body extends Component {
    * Adds a click action to each row, called with the clicked row's data as an argument.
    * Can be used with both the blockless and block invocations.
    *
-   * @argument {function} onRowClick
+   * @argument onRowClick
+   * @type Function
    */
 
   @action

--- a/addon/components/yeti-table/header.js
+++ b/addon/components/yeti-table/header.js
@@ -1,6 +1,6 @@
-import { tagName } from '@ember-decorators/component';
-import Component from '@ember/component';
 import { action } from '@ember/object';
+
+import Component from '@glimmer/component';
 
 /**
   Renders a `<thead>` element and yields the column component.
@@ -20,26 +20,11 @@ import { action } from '@ember/object';
   @yield {object} header
   @yield {Component} header.column       the column component
 */
-@tagName('')
 class Header extends Component {
-  theme;
-
-  sortable;
-
-  sortSequence;
-
-  onColumnClick;
-
-  parent;
-
-  columns;
-
-  trClass;
-
   @action
   onColumnClickHeader(column, e) {
-    if (this.get('onColumnClick') && column.get('sortable')) {
-      this.get('onColumnClick')(column, e);
+    if (this.args.onColumnClick && column.sortable) {
+      this.args.onColumnClick(column, e);
     }
   }
 }

--- a/addon/components/yeti-table/table.js
+++ b/addon/components/yeti-table/table.js
@@ -1,5 +1,4 @@
-import { tagName } from '@ember-decorators/component';
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 
 /**
   A simple component that just renders the `<table>` element with the correct
@@ -28,7 +27,7 @@ import Component from '@ember/component';
   ```
 */
 
-@tagName('')
+// eslint-disable-next-line ember/no-empty-glimmer-component-classes
 class Table extends Component {}
 
 export default Table;

--- a/addon/components/yeti-table/tbody.js
+++ b/addon/components/yeti-table/tbody.js
@@ -33,7 +33,8 @@ class TBody extends Component {
    * Adds a click action to each row, called with the clicked row's data as an argument.
    * Can be used with both the blockless and block invocations.
    *
-   * @argument {fucntion} onRowClick
+   * @argument onRowClick
+   * @type Function
    */
 }
 

--- a/addon/components/yeti-table/tbody/row.js
+++ b/addon/components/yeti-table/tbody/row.js
@@ -43,7 +43,8 @@ class TBodyRow extends Component {
   /**
    * Adds a click action to the row.
    *
-   * @argument {function} onClick
+   * @argument onClick
+   * @type Function
    */
 
   cells = [];

--- a/addon/components/yeti-table/thead.js
+++ b/addon/components/yeti-table/thead.js
@@ -21,7 +21,10 @@ import Component from '@glimmer/component';
 // eslint-disable-next-line ember/no-empty-glimmer-component-classes
 class THead extends Component {
   /**
-   * @argument {function} onColumnClick - action that is called when the column header is clicked
+   * Adds a click action to the thead, called with the clicked column as an argument.
+   *
+   * @argument onColumnClick - action that is called when the column header is clicked
+   * @type Function
    */
 }
 

--- a/addon/components/yeti-table/thead.js
+++ b/addon/components/yeti-table/thead.js
@@ -1,5 +1,4 @@
-import { tagName } from '@ember-decorators/component';
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 
 /**
   Renders a `<thead>` element and yields the row component.
@@ -19,19 +18,11 @@ import Component from '@ember/component';
   @yield {object} head
   @yield {Component} head.row
 */
-@tagName('')
+// eslint-disable-next-line ember/no-empty-glimmer-component-classes
 class THead extends Component {
-  theme;
-
-  sortable;
-
-  sortSequence;
-
-  parent;
-
-  columns;
-
-  onColumnClick;
+  /**
+   * @argument {function} onColumnClick - action that is called when the column header is clicked
+   */
 }
 
 export default THead;

--- a/addon/components/yeti-table/thead/row.hbs
+++ b/addon/components/yeti-table/thead/row.hbs
@@ -1,6 +1,6 @@
 <tr class="{{@trClass}} {{@theme.theadRow}} {{@theme.row}}" ...attributes>
   {{yield (hash
-    column=(component "ember-yeti-table@yeti-table/thead/row/column" sortable=this.sortable sortSequence=@sortSequence onClick=@onColumnClick theme=@theme parent=@parent)
+    column=(component "ember-yeti-table@yeti-table/thead/row/column" sortable=@sortable sortSequence=@sortSequence onClick=@onColumnClick theme=@theme parent=@parent)
     cell=(component "ember-yeti-table@yeti-table/thead/row/cell" theme=@theme parent=this)
   )}}
 </tr>

--- a/addon/components/yeti-table/thead/row.js
+++ b/addon/components/yeti-table/thead/row.js
@@ -1,6 +1,4 @@
-import { tagName } from '@ember-decorators/component';
-import { A } from '@ember/array';
-import Component from '@ember/component';
+import Component from '@glimmer/component';
 
 /**
   Renders a `<tr>` element and yields the column and cell component.
@@ -19,42 +17,32 @@ import Component from '@ember/component';
   @yield {Component} column
   @yield {Component} cell
 */
-@tagName('')
 class THeadRow extends Component {
-  theme;
-
-  parent;
-
-  columns;
-
-  sortable = true;
-
-  sort = null;
-
-  sortSequence;
-
-  onColumnClick;
-
-  cells = A();
+  cells = [];
 
   registerCell(cell) {
-    let columns = this.get('columns');
-    let prop = cell.get('prop');
+    let column;
 
-    if (prop) {
-      let column = columns.findBy('prop', prop);
-      cell.set('column', column);
+    if (cell.prop) {
+      column = this.args.columns.findBy('prop', cell.prop);
+      cell.column = column;
     } else {
-      let index = this.get('cells.length');
-      let column = columns[index];
-      cell.set('column', column);
+      let index = this.cells.length;
+      column = this.args.columns[index];
+
+      return column;
     }
 
-    this.get('cells').addObject(cell);
+    this.cells.push(cell);
+
+    return column;
   }
 
   unregisterCell(cell) {
-    this.get('cells').removeObject(cell);
+    let cells = this.cells;
+    let index = cells.indexOf(cell);
+
+    cells.splice(index, 1);
   }
 }
 

--- a/addon/components/yeti-table/thead/row/cell.hbs
+++ b/addon/components/yeti-table/thead/row/cell.hbs
@@ -1,4 +1,4 @@
-{{#if this.visible}}
+{{#if this.column.visible}}
   <th class="{{@class}} {{@theme.theadCell}}" ...attributes>
     {{yield}}
   </th>

--- a/addon/components/yeti-table/thead/row/cell.js
+++ b/addon/components/yeti-table/thead/row/cell.js
@@ -1,6 +1,4 @@
-import { tagName } from '@ember-decorators/component';
-import Component from '@ember/component';
-import { reads } from '@ember/object/computed';
+import Component from '@glimmer/component';
 
 /**
   An component yielded from the head.row component that is used to define
@@ -23,33 +21,18 @@ import { reads } from '@ember/object/computed';
   @yield {object} cell
 
  */
-@tagName('')
 class THeadCell extends Component {
-  theme;
+  // Assigned when the cell is registered
+  column = undefined;
 
-  parent;
-
-  /**
-   * Controls the visibility of the current cell. Keep in mind that this property
-   * won't just hide the column using css. The DOM for the column will be removed.
-   * Defaults to the `visible` argument of the corresponding column.
-   */
-  @reads('column.visible')
-  visible;
-
-  init() {
-    super.init(...arguments);
-
-    if (this.get('parent')) {
-      this.get('parent').registerCell(this);
-    }
+  constructor() {
+    super(...arguments);
+    this.column = this.args.parent?.registerCell(this);
   }
 
-  willDestroyElement() {
-    super.willDestroyElement(...arguments);
-    if (this.get('parent')) {
-      this.get('parent').unregisterCell(this);
-    }
+  willDestroy() {
+    super.willDestroy(...arguments);
+    this.args.parent?.unregisterCell(this);
   }
 }
 


### PR DESCRIPTION
Once @sly7-7 completes the footers that all the easy ones.

column, and yeti-table will take more time.   pagination component is pretty easy but I see no tests for that component so will have to write some.