### PR TITLE
Updated yeti-table and pagination to glimmer components

### DIFF
--- a/addon/components/yeti-table.hbs
+++ b/addon/components/yeti-table.hbs
@@ -1,5 +1,5 @@
 {{#let (hash
-  table=(component "ember-yeti-table@yeti-table/table" theme=this.mergedTheme)
+  table=(component "ember-yeti-table@yeti-table/table" theme=this.mergedTheme parent=this)
   header=(component "ember-yeti-table@yeti-table/header"
     columns=this.columns
     onColumnClick=this.onColumnSort
@@ -54,11 +54,12 @@
   visibleRows=this.processedData
   theme=this.mergedTheme
 ) as |api|}}
-
+  {{did-update this.notifyPropertyChange @theme @data @loadData @pagination @pageSize @pageNumber @filter @filterFunction
+               @filterUsing @sortable @sortFunction @compareFunction @sortSequence @isColumnVisible}}
   {{#if this.renderTableElement}}
-    <EmberYetiTable@YetiTable::Table @theme={{this.mergedTheme}} ...attributes>
+    <api.table ...attributes>
       {{yield api}}
-    </EmberYetiTable@YetiTable::Table>
+    </api.table>
   {{else}}
     {{yield api}}
   {{/if}}

--- a/addon/components/yeti-table/pagination.js
+++ b/addon/components/yeti-table/pagination.js
@@ -1,7 +1,8 @@
-import { tagName } from '@ember-decorators/component';
-import Component from '@ember/component';
 import { action } from '@ember/object';
 import { or } from '@ember/object/computed';
+
+import Component from '@glimmer/component';
+import { localCopy } from 'tracked-toolbox';
 
 /**
   Simple pagination controls component that is included to help you get started quickly.
@@ -29,20 +30,19 @@ import { or } from '@ember/object/computed';
   ```
 */
 
-@tagName('')
 class Pagination extends Component {
-  theme;
+  // theme;
 
-  paginationData;
+  // paginationData;
 
-  paginationActions;
+  // paginationActions;
 
-  disabled;
+  // disabled;
 
-  @or('paginationData.isFirstPage', 'disabled')
+  @or('args.paginationData.isFirstPage', 'args.disabled')
   shouldDisablePrevious;
 
-  @or('paginationData.isLastPage', 'disabled')
+  @or('args.paginationData.isLastPage', 'args.disabled')
   shouldDisableNext;
 
   /**
@@ -50,26 +50,30 @@ class Pagination extends Component {
    * Particularly useful with an array helper, e.g `@pageSizes={{array 10 12 23 50 100}}`
    * Defaults to `[10, 15, 20, 25]`.
    */
-  pageSizes = [10, 15, 20, 25];
+  @localCopy('args.pageSizes', [10, 15, 20, 25])
+  pageSizes;
 
   /**
    * Used to show/hide some textual information about the current page. Defaults to `true`.
    */
-  showInfo = true;
+  @localCopy('args.showInfo', true)
+  showInfo;
 
   /**
    * Used to show/hide the page size selector. Defaults to `true`.
    */
-  showPageSizeSelector = true;
+  @localCopy('args.showPageSizeSelector', true)
+  showPageSizeSelector;
 
   /**
    * Used to show/hide the previous and next page buttons. Defaults to `true`.
    */
-  showButtons = true;
+  @localCopy('args.showButtons', true)
+  showButtons;
 
   @action
   changePageSize(ev) {
-    this.paginationActions.changePageSize(ev.target.value);
+    this.args.paginationActions.changePageSize(ev.target.value);
   }
 }
 

--- a/addon/components/yeti-table/table.hbs
+++ b/addon/components/yeti-table/table.hbs
@@ -1,3 +1,3 @@
-<table class={{@theme.table}} ...attributes>
+<table class={{@theme.table}} ...attributes {{did-insert @parent.createProperties}} {{did-insert @parent.registerApi}}>
   {{yield}}
 </table>

--- a/addon/components/yeti-table/thead/row/column.js
+++ b/addon/components/yeti-table/thead/row/column.js
@@ -1,7 +1,7 @@
 import { isArray } from '@ember/array';
 import { assert } from '@ember/debug';
 import { action } from '@ember/object';
-// Can be removed when yeti-table component is altered to user glimmer
+// Required as long as computeds are used on yeti-table.js
 import { dependentKeyCompat } from '@ember/object/compat';
 import { equal, or } from '@ember/object/computed';
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1339,28 +1339,11 @@
         }
       }
     },
-    "@ember-decorators/component": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@ember-decorators/component/-/component-6.1.1.tgz",
-      "integrity": "sha512-Cj8tY/c0MC/rsipqsiWLh3YVN72DK92edPYamD/HzvftwzC6oDwawWk8RmStiBnG9PG/vntAt41l3S7HSSA+1Q==",
-      "requires": {
-        "@ember-decorators/utils": "^6.1.1",
-        "ember-cli-babel": "^7.1.3"
-      }
-    },
-    "@ember-decorators/object": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/@ember-decorators/object/-/object-6.1.1.tgz",
-      "integrity": "sha512-cb4CNR9sRoA31J3FCOFLDuR9ztM4wO9w1WlS4JeNRS7Z69SlB/XSXB/vplA3i9OOaXEy/zKWbu5ndZrHz0gvLw==",
-      "requires": {
-        "@ember-decorators/utils": "^6.1.1",
-        "ember-cli-babel": "^7.1.3"
-      }
-    },
     "@ember-decorators/utils": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@ember-decorators/utils/-/utils-6.1.1.tgz",
       "integrity": "sha512-0KqnoeoLKb6AyoSU65TRF5T85wmS4uDn06oARddwNPxxf/lt5jQlh41uX3W7V/fWL9tPu8x1L1Vvpc80MN1+YA==",
+      "dev": true,
       "requires": {
         "ember-cli-babel": "^7.1.3"
       }
@@ -3249,7 +3232,6 @@
       "version": "0.6.14",
       "resolved": "https://registry.npmjs.org/ansi-to-html/-/ansi-to-html-0.6.14.tgz",
       "integrity": "sha512-7ZslfB1+EnFSDO5Ju+ue5Y6It19DRnZXWv8jrGHgIlPna5Mh4jz7BV5jCbQneXNFurQcKoolaaAjHtgSBfOIuA==",
-      "dev": true,
       "requires": {
         "entities": "^1.1.2"
       }
@@ -3580,8 +3562,7 @@
     "at-least-node": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/at-least-node/-/at-least-node-1.0.0.tgz",
-      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==",
-      "dev": true
+      "integrity": "sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg=="
     },
     "atob": {
       "version": "2.1.2",
@@ -6120,7 +6101,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/broccoli-stew/-/broccoli-stew-3.0.0.tgz",
       "integrity": "sha512-NXfi+Vas24n3Ivo21GvENTI55qxKu7OwKRnCLWXld8MiLiQKQlWIq28eoARaFj0lTUFwUa4jKZeA7fW9PiWQeg==",
-      "dev": true,
       "requires": {
         "broccoli-debug": "^0.6.5",
         "broccoli-funnel": "^2.0.0",
@@ -6142,7 +6122,6 @@
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/broccoli-funnel/-/broccoli-funnel-2.0.2.tgz",
           "integrity": "sha512-/vDTqtv7ipjEZQOVqO4vGDVAOZyuYzQ/EgGoyewfOgh1M7IQAToBKZI0oAQPgMBeFPPlIbfMuAngk+ohPBuaHQ==",
-          "dev": true,
           "requires": {
             "array-equal": "^1.0.0",
             "blank-object": "^1.0.1",
@@ -6163,7 +6142,6 @@
               "version": "1.3.1",
               "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
               "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
-              "dev": true,
               "requires": {
                 "promise-map-series": "^0.2.1",
                 "quick-temp": "^0.1.3",
@@ -6175,7 +6153,6 @@
               "version": "2.6.9",
               "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
               "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-              "dev": true,
               "requires": {
                 "ms": "2.0.0"
               }
@@ -6184,7 +6161,6 @@
               "version": "0.3.4",
               "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.4.tgz",
               "integrity": "sha512-ttGcuHA/OBnN2pcM6johpYlEms7XpO5/fyKIr48541xXedan4roO8cS1Q2S/zbbjGH/BarYDAMeS2Mi9HE5Tig==",
-              "dev": true,
               "requires": {
                 "ensure-posix-path": "^1.0.0",
                 "matcher-collection": "^1.0.0"
@@ -6196,7 +6172,6 @@
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/broccoli-merge-trees/-/broccoli-merge-trees-3.0.2.tgz",
           "integrity": "sha512-ZyPAwrOdlCddduFbsMyyFzJUrvW6b04pMvDiAQZrCwghlvgowJDY+EfoXn+eR1RRA5nmGHJ+B68T63VnpRiT1A==",
-          "dev": true,
           "requires": {
             "broccoli-plugin": "^1.3.0",
             "merge-trees": "^2.0.0"
@@ -6206,7 +6181,6 @@
               "version": "1.3.1",
               "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-1.3.1.tgz",
               "integrity": "sha512-DW8XASZkmorp+q7J4EeDEZz+LoyKLAd2XZULXyD9l4m9/hAKV3vjHmB1kiUshcWAYMgTP1m2i4NnqCE/23h6AQ==",
-              "dev": true,
               "requires": {
                 "promise-map-series": "^0.2.1",
                 "quick-temp": "^0.1.3",
@@ -6220,7 +6194,6 @@
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/broccoli-plugin/-/broccoli-plugin-2.1.0.tgz",
           "integrity": "sha512-ElE4caljW4slapyEhSD9jU9Uayc8SoSABWdmY9SqbV8DHNxU6xg1jJsPcMm+cXOvggR3+G+OXAYQeFjWVnznaw==",
-          "dev": true,
           "requires": {
             "promise-map-series": "^0.2.1",
             "quick-temp": "^0.1.3",
@@ -6232,7 +6205,6 @@
           "version": "8.1.0",
           "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
           "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-          "dev": true,
           "requires": {
             "graceful-fs": "^4.2.0",
             "jsonfile": "^4.0.0",
@@ -6242,14 +6214,12 @@
         "ms": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-          "dev": true
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "rimraf": {
           "version": "2.7.1",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.7.1.tgz",
           "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
-          "dev": true,
           "requires": {
             "glob": "^7.1.3"
           }
@@ -6258,7 +6228,6 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-1.1.4.tgz",
           "integrity": "sha512-nowc9thB/Jg0KW4TgxoRjLLYRPvl3DB/98S89r4ZcJqq2B0alNcKDh6pzLkBSkPMzRSMsJghJHQi79qw0YWEkA==",
-          "dev": true,
           "requires": {
             "@types/minimatch": "^3.0.3",
             "ensure-posix-path": "^1.1.0",
@@ -8057,7 +8026,6 @@
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
       "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
-      "dev": true,
       "requires": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -9079,6 +9047,15 @@
             "lru-cache": "^6.0.0"
           }
         }
+      }
+    },
+    "ember-cached-decorator-polyfill": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ember-cached-decorator-polyfill/-/ember-cached-decorator-polyfill-0.1.1.tgz",
+      "integrity": "sha512-mMdzPQuR4D6hNXkdVFfIWTQbBERNFpm5G36sC4DzogQYDcFKQf5QXLVCmK+3KsEKjJOwPeXmClMQTNUfgtb5Ig==",
+      "requires": {
+        "ember-cache-primitive-polyfill": "^1.0.1",
+        "ember-cli-babel": "^7.21.0"
       }
     },
     "ember-cli": {
@@ -11961,16 +11938,6 @@
         "ember-inflector": "^3.0.1"
       }
     },
-    "ember-decorators": {
-      "version": "6.1.1",
-      "resolved": "https://registry.npmjs.org/ember-decorators/-/ember-decorators-6.1.1.tgz",
-      "integrity": "sha512-63vZPntPn1aqMyeNRLoYjJD+8A8obd+c2iZkJflswpDRNVIsp2m7aQdSCtPt4G0U/TEq2251g+N10maHX3rnJQ==",
-      "requires": {
-        "@ember-decorators/component": "^6.1.1",
-        "@ember-decorators/object": "^6.1.1",
-        "ember-cli-babel": "^7.7.3"
-      }
-    },
     "ember-destroyable-polyfill": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/ember-destroyable-polyfill/-/ember-destroyable-polyfill-2.0.3.tgz",
@@ -13671,6 +13638,103 @@
         }
       }
     },
+    "ember-render-helpers": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/ember-render-helpers/-/ember-render-helpers-0.2.0.tgz",
+      "integrity": "sha512-MnqGS8BnY3GJ+n5RZVVRqCwKjfXXMr5quKyqNu1vxft8oslOJuZ1f1dOesQouD+6LwD4Y9tWRVKNw+LOqM9ocw==",
+      "requires": {
+        "ember-cli-babel": "^7.23.0",
+        "ember-cli-typescript": "^4.0.0"
+      },
+      "dependencies": {
+        "ember-cli-typescript": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ember-cli-typescript/-/ember-cli-typescript-4.1.0.tgz",
+          "integrity": "sha512-zSuKG8IQuYE3vS+c7V0mHJqwrN/4Wo9Wr50+0NUjnZH3P99ChynczQHu/P7WSifkO6pF6jaxwzf09XzWvG8sVw==",
+          "requires": {
+            "ansi-to-html": "^0.6.6",
+            "broccoli-stew": "^3.0.0",
+            "debug": "^4.0.0",
+            "execa": "^4.0.0",
+            "fs-extra": "^9.0.1",
+            "resolve": "^1.5.0",
+            "rsvp": "^4.8.1",
+            "semver": "^7.3.2",
+            "stagehand": "^1.0.0",
+            "walk-sync": "^2.2.0"
+          }
+        },
+        "execa": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-4.1.0.tgz",
+          "integrity": "sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==",
+          "requires": {
+            "cross-spawn": "^7.0.0",
+            "get-stream": "^5.0.0",
+            "human-signals": "^1.1.1",
+            "is-stream": "^2.0.0",
+            "merge-stream": "^2.0.0",
+            "npm-run-path": "^4.0.0",
+            "onetime": "^5.1.0",
+            "signal-exit": "^3.0.2",
+            "strip-final-newline": "^2.0.0"
+          }
+        },
+        "fs-extra": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.1.0.tgz",
+          "integrity": "sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==",
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^2.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
+          "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^2.0.0"
+          }
+        },
+        "matcher-collection": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-2.0.1.tgz",
+          "integrity": "sha512-daE62nS2ZQsDg9raM0IlZzLmI2u+7ZapXBwdoeBUKAYERPDDIc0qNqA8E0Rp2D+gspKR7BgIFP52GeujaGXWeQ==",
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "minimatch": "^3.0.2"
+          }
+        },
+        "semver": {
+          "version": "7.3.4",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
+          "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
+          "requires": {
+            "lru-cache": "^6.0.0"
+          }
+        },
+        "universalify": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.0.tgz",
+          "integrity": "sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ=="
+        },
+        "walk-sync": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-2.2.0.tgz",
+          "integrity": "sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==",
+          "requires": {
+            "@types/minimatch": "^3.0.3",
+            "ensure-posix-path": "^1.1.0",
+            "matcher-collection": "^2.0.0",
+            "minimatch": "^3.0.4"
+          }
+        }
+      }
+    },
     "ember-resolver": {
       "version": "8.0.2",
       "resolved": "https://registry.npmjs.org/ember-resolver/-/ember-resolver-8.0.2.tgz",
@@ -15207,8 +15271,7 @@
     "entities": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==",
-      "dev": true
+      "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
     },
     "errlop": {
       "version": "2.2.0",
@@ -17138,7 +17201,6 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
       "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "dev": true,
       "requires": {
         "pump": "^3.0.0"
       }
@@ -17904,8 +17966,7 @@
     "human-signals": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-1.1.1.tgz",
-      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==",
-      "dev": true
+      "integrity": "sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw=="
     },
     "husky": {
       "version": "4.3.8",
@@ -18744,8 +18805,7 @@
     "is-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.0.tgz",
-      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==",
-      "dev": true
+      "integrity": "sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw=="
     },
     "is-symbol": {
       "version": "1.0.3",
@@ -18809,8 +18869,7 @@
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
-      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
-      "dev": true
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isobject": {
       "version": "3.0.1",
@@ -20369,8 +20428,7 @@
     "merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
-      "dev": true
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
     "merge-trees": {
       "version": "2.0.0",
@@ -20451,8 +20509,7 @@
     "mimic-fn": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "dev": true
+      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg=="
     },
     "mimic-response": {
       "version": "1.0.1",
@@ -21120,7 +21177,6 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
       "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dev": true,
       "requires": {
         "path-key": "^3.0.0"
       }
@@ -21307,7 +21363,6 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
       "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dev": true,
       "requires": {
         "mimic-fn": "^2.1.0"
       }
@@ -21769,8 +21824,7 @@
     "path-key": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
-      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
-      "dev": true
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="
     },
     "path-parse": {
       "version": "1.0.6",
@@ -23573,7 +23627,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
       "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
-      "dev": true,
       "requires": {
         "shebang-regex": "^3.0.0"
       }
@@ -23581,8 +23634,7 @@
     "shebang-regex": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
-      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
-      "dev": true
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="
     },
     "shell-quote": {
       "version": "1.7.2",
@@ -23599,8 +23651,7 @@
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-      "dev": true
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
     },
     "silent-error": {
       "version": "1.1.1",
@@ -24178,7 +24229,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/stagehand/-/stagehand-1.0.0.tgz",
       "integrity": "sha512-zrXl0QixAtSHFyN1iv04xOBgplbT4HgC8T7g+q8ESZbDNi5uZbMtxLukFVXPJ5Nl7zCYvYcrT3Mj24WYCH93hw==",
-      "dev": true,
       "requires": {
         "debug": "^4.1.0"
       }
@@ -24460,8 +24510,7 @@
     "strip-final-newline": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "dev": true
+      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -26382,7 +26431,6 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
       "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
-      "dev": true,
       "requires": {
         "isexe": "^2.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -38,9 +38,10 @@
     "@ember/render-modifiers": "^1.0.2",
     "deepmerge": "^4.2.2",
     "ember-auto-import": "^1.10.1",
+    "ember-cached-decorator-polyfill": "^0.1.1",
     "ember-cli-babel": "^7.23.1",
     "ember-cli-htmlbars": "^5.3.1",
-    "ember-decorators": "^6.1.1",
+    "ember-render-helpers": "^0.2.0",
     "tracked-toolbox": "^1.2.1"
   },
   "devDependencies": {

--- a/tests/integration/components/yeti-table/async-data-test.js
+++ b/tests/integration/components/yeti-table/async-data-test.js
@@ -880,8 +880,12 @@ module('Integration | Component | yeti-table (async)', function (hooks) {
       });
     });
 
+    this.register = api => {
+      this.tableApi = api;
+    };
+
     await render(hbs`
-      <YetiTable @loadData={{this.loadData}} @registerApi={{fn (mut this.tableApi)}} as |table|>
+      <YetiTable @loadData={{this.loadData}} @registerApi={{fn this.register}} as |table|>
 
         <table.header as |header|>
           <header.column @prop="firstName">

--- a/tests/integration/components/yeti-table/filtering-test.js
+++ b/tests/integration/components/yeti-table/filtering-test.js
@@ -69,7 +69,7 @@ module('Integration | Component | yeti-table (filtering)', function (hooks) {
 
   test('updating filter filters rows', async function (assert) {
     await render(hbs`
-      <YetiTable @data={{this.data}} @filter={{filterText}} as |table|>
+      <YetiTable @data={{this.data}} @filter={{this.filterText}} as |table|>
 
         <table.header as |header|>
           <header.column @prop="firstName">
@@ -96,7 +96,8 @@ module('Integration | Component | yeti-table (filtering)', function (hooks) {
     assert.dom('tbody tr:nth-child(4) td:nth-child(1)').hasText('Tom');
     assert.dom('tbody tr:nth-child(5) td:nth-child(1)').hasText('Tom');
 
-    this.set('filterText', 'Baderous');
+    set(this, 'filterText', 'Baderous');
+    await settled();
 
     assert.dom('tbody tr').exists({ count: 1 });
 

--- a/tests/integration/components/yeti-table/pagination-test.js
+++ b/tests/integration/components/yeti-table/pagination-test.js
@@ -302,8 +302,12 @@ module('Integration | Component | yeti-table (pagination)', function (hooks) {
   });
 
   test('using registered api to update pagination state works', async function (assert) {
+    this.register = api => {
+      this.tableApi = api;
+    };
+
     await render(hbs`
-      <YetiTable @data={{this.data}} @pagination={{true}} @pageSize={{15}} @registerApi={{fn (mut this.tableApi)}} as |table|>
+      <YetiTable @data={{this.data}} @pagination={{true}} @pageSize={{15}} @registerApi={{fn this.register}} as |table|>
 
         <table.header as |header|>
           <header.column @prop="firstName">


### PR DESCRIPTION
https://github.com/miguelcobain/ember-yeti-table/issues/344

This is everything converted with one failing test.

Its the one that says loadData should be called only once but its called twice. I tried several options, but the way tracking works I just couldnt find a way to know the value changed but treat undefined and "" the same. 

Perhaps you can find a way if you wish to play with it. Else we just change the test to say its called twice, or remove the test if it is no longer testing something.

The main key to things reacting to changes without using the didReceiveAttrs methods if the following
```hbs
  {{did-update this.notifyPropertyChange @theme @data @loadData @pagination @pageSize @pageNumber @filter @filterFunction
               @filterUsing @sortable @sortFunction @compareFunction @sortSequence @isColumnVisible}}

```
And that is only needed because of `data` taking a function. All the rest of the screen is reactive off tracked. 

Computeds are still used as they will still allow POJOs to still work. Although @tracked is the new way in your code, when you have to watch on objects you are not in control of, I have not seen that ember computed has been deprecated for that use.  