### PR TITLE
Yield the property name for the body cell

### DIFF
--- a/addon/components/yeti-table/tbody/row/cell.hbs
+++ b/addon/components/yeti-table/tbody/row/cell.hbs
@@ -1,5 +1,9 @@
 {{#if this.column.visible}}
   <td class="{{@class}} {{this.column.columnClass}} {{@theme.tbodyCell}}" ...attributes>
-    {{yield}}
+    {{yield
+      (hash
+        prop=this.column.prop
+      )
+    }}
   </td>
 {{/if}}

--- a/addon/components/yeti-table/tbody/row/cell.js
+++ b/addon/components/yeti-table/tbody/row/cell.js
@@ -7,7 +7,15 @@ import Component from '@glimmer/component';
     {{person.firstName}}
   </row.cell>
   ```
-*/
+
+ If the prop name was used when the column header was defined, it is yielded in a hash
+ ```hbs
+ <row.cell as |column|>
+   {{get person column.prop}}
+ </row.cell>
+ ```
+
+ */
 class TBodyCell extends Component {
   // Assigned when the cell is registered
   column = undefined;

--- a/tests/integration/components/yeti-table/general-test.js
+++ b/tests/integration/components/yeti-table/general-test.js
@@ -109,8 +109,8 @@ module('Integration | Component | yeti-table (general)', function (hooks) {
             <row.cell>
               Custom {{person.firstName}}
             </row.cell>
-            <row.cell>
-              {{person.lastName}}
+            <row.cell as |column|>
+              {{get person column.prop}}
             </row.cell>
             <row.cell>
               {{person.points}}


### PR DESCRIPTION
Allow for the cell to yield its property name. Fixed https://github.com/miguelcobain/ember-yeti-table/issues/444

```hbs
 <row.cell as |column|>
   {{get person column.prop}}
 </row.cell>
 ```