### PR TITLE
Support Ember v6

### DIFF
--- a/ember-yeti-table/package.json
+++ b/ember-yeti-table/package.json
@@ -71,7 +71,7 @@
     "webpack": "^5.90.1"
   },
   "peerDependencies": {
-    "ember-source": "^4.0.0 || ^5.0.0"
+    "ember-source": ">= 4.0.0"
   },
   "engines": {
     "node": "16.* || >= 18"


### PR DESCRIPTION
This PR adds support for Ember v6. It's covered by tests through `ember-release` scenario.