### PR TITLE
Ensure tests are run against local ember-yeti-table package and not published one

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -250,8 +250,8 @@ importers:
         specifier: ^3.0.0
         version: 3.0.0
       ember-yeti-table:
-        specifier: 2.0.1
-        version: 2.0.1(@babel/core@7.26.0)(@glint/template@1.3.0)(ember-source@5.6.0(@babel/core@7.26.0)(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.97.0))
+        specifier: workspace:*
+        version: file:ember-yeti-table(@babel/core@7.26.0)(@glint/template@1.3.0)(ember-source@5.6.0(@babel/core@7.26.0)(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.97.0))
       eslint:
         specifier: ^8.56.0
         version: 8.57.1
@@ -4286,8 +4286,8 @@ packages:
     resolution: {integrity: sha512-b7RrRxkwCBEJxM2zR34dEzIET81BOZWTcYNJtkidLycLQvdbxPys5QJEjJ/IfDikT/z5HuQBdZRKBhXI0vZNXQ==}
     engines: {node: 10.* || >= 12}
 
-  ember-yeti-table@2.0.1:
-    resolution: {integrity: sha512-z92/0aDgYOYpvu7VCBclMd9p5891LQvfwo0xUOT2IIHJlrqNxH6Z1RzpRcRSIkJ7WImoXpJ3XxfAPxZaOwk2SA==}
+  ember-yeti-table@file:ember-yeti-table:
+    resolution: {directory: ember-yeti-table, type: directory}
     engines: {node: 16.* || >= 18}
     peerDependencies:
       ember-source: '>= 4.0.0'
@@ -14446,7 +14446,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  ember-yeti-table@2.0.1(@babel/core@7.26.0)(@glint/template@1.3.0)(ember-source@5.6.0(@babel/core@7.26.0)(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.97.0)):
+  ember-yeti-table@file:ember-yeti-table(@babel/core@7.26.0)(@glint/template@1.3.0)(ember-source@5.6.0(@babel/core@7.26.0)(@glimmer/component@1.1.2(@babel/core@7.26.0))(@glint/template@1.3.0)(rsvp@4.8.5)(webpack@5.97.0)):
     dependencies:
       '@ember/test-waiters': 3.1.0
       '@embroider/addon-shim': 1.9.0

--- a/test-app/config/ember-try.js
+++ b/test-app/config/ember-try.js
@@ -27,7 +27,7 @@ module.exports = async function () {
         name: 'ember-lts-4.12',
         npm: {
           devDependencies: {
-            'ember-source': '~4.12.0'
+            'ember-source': '4.12.3'
           }
         }
       },

--- a/test-app/package.json
+++ b/test-app/package.json
@@ -100,7 +100,7 @@
     "ember-template-lint": "^5.13.0",
     "ember-truth-helpers": "^4.0.3",
     "ember-try": "^3.0.0",
-    "ember-yeti-table": "2.0.1",
+    "ember-yeti-table": "workspace:*",
     "eslint": "^8.56.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-ember": "^12.0.0",


### PR DESCRIPTION
In some scenarios PNPM was not linking the test-app against the local version of the `ember-yeti-package` but against the published one. I was able to reproduce it whenever I touched any dependency in the test-app. This caused the Ember Try scenarios to fail in CI.

Using the workspace protocol ensures that PNPM links the test-app against the local version of the ember-yeti-table package (or fails if it cannot do so). PNPM will not link against the published package in any case.